### PR TITLE
Only require solidus_core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'solidus', github: 'solidusio/solidus', branch: solidus_branch
 gem 'solidus_auth_devise'
 
 case ENV['DB']
-when 'postgres'
+when 'postgresql'
   gem 'pg'
 when 'mysql'
   gem 'mysql2'

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler::GemHelper.install_tasks
+require 'solidus_dev_support/rake_tasks'
+SolidusDevSupport::RakeTasks.install
 
-require 'rspec/core/rake_task'
-require 'spree/testing_support/extension_rake'
-
-RSpec::Core::RakeTask.new
-
-task :default do
-  if Dir["spec/dummy"].empty?
-    Rake::Task[:test_app].invoke
-    Dir.chdir("../../")
-  end
-  Rake::Task[:spec].invoke
-end
-
-desc 'Generates a dummy app for testing'
-task :test_app do
-  ENV['LIB_NAME'] = 'solidus_avatax_certified'
-  Rake::Task['extension:test_app'].invoke
-end
+task default: 'extension:specs'

--- a/lib/generators/solidus_avatax_certified/install/install_generator.rb
+++ b/lib/generators/solidus_avatax_certified/install/install_generator.rb
@@ -3,6 +3,8 @@
 module SolidusAvataxCertified
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      class_option :auto_run_migrations, type: :boolean, default: false
+
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_avatax_certified\n"
         append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_avatax_certified\n"
@@ -12,21 +14,12 @@ module SolidusAvataxCertified
         run 'bundle exec rake railties:install:migrations FROM=solidus_avatax_certified'
       end
 
-      def auto_migrate?
-        ENV['AUTO_RUN_MIGRATIONS'] =~ /true/i
-      end
-
       def run_migrations
-        # hiding this inside parent method so it's not auto-run by rails generator
-        def migration_prompt_approved?
-          result = ask('Would you like to run the migrations now? [Y/n]')
-          result !~ /n/i
-        end
-
-        if auto_migrate? || migration_prompt_approved?
-          run 'bundle exec rake db:migrate'
+        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
+        if run_migrations
+          run 'bin/rails db:migrate'
         else
-          puts 'Skipping rake db:migrate, don\'t forget to run it!'
+          puts 'Skipping bin/rails db:migrate, don\'t forget to run it!' # rubocop:disable Rails/Output
         end
       end
 

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'json', '~> 2.0'
   s.add_dependency 'logging', '~> 2.0'
-  s.add_dependency 'solidus', solidus_version
+  s.add_dependency 'solidus_core', solidus_version
   s.add_dependency 'solidus_support'
 
   s.add_development_dependency 'capybara'
@@ -37,11 +37,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'github_changelog_generator'
   s.add_development_dependency 'rspec-rails', '~> 4.0.0.beta2'
-  s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'solidus_dev_support'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'webmock'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,7 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require "webdrivers"
 
-require "solidus_support/extension/feature_helper"
-require 'spree/testing_support/controller_requests'
+require "solidus_dev_support/rspec/feature_helper"
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
@@ -21,4 +20,10 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "./spec/examples.txt"
 
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
+
+  # config.use_transactional_fixtures = false
+
+  config.before(:example) do
+    DatabaseCleaner.clean_with :truncation
+  end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.find_definitions


### PR DESCRIPTION
Requiring solidus istead of `solidus_core` requires a ton of code that
might not even be used in the application requiring this extension.

By requiring just `solidus_core` life will be easier for people that
are, for example, not using solidus_frontend.

The new `solidus_dev_support` gem has been used in order to make the
specs pass.